### PR TITLE
updates from testing cpp-linter/cpp-linter-action#81

### DIFF
--- a/.github/workflows/cpp-lint-action.yml
+++ b/.github/workflows/cpp-lint-action.yml
@@ -15,6 +15,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: true
 
       - name: Cache the build artifacts
         id: cache-build

--- a/.github/workflows/cpp-lint-action.yml
+++ b/.github/workflows/cpp-lint-action.yml
@@ -18,16 +18,19 @@ jobs:
         with:
           submodules: true
 
-      - name: Cache the build artifacts
-        id: cache-build
-        uses: actions/cache@v3
-        with:
-          path: build
-          key: ${{ hashFiles('src/CMakeLists.txt', 'src/demo.cpp', 'src/demo.hpp') }}
+      # - name: Cache the build artifacts
+      #   id: cache-build
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: build
+      #     key: ${{ hashFiles('src/CMakeLists.txt', 'src/demo.cpp', 'src/demo.hpp') }}
 
-      - name: Generate compilation database
-        if: steps.cache-build.outputs.cache-hit != 'true'
-        run: mkdir build && cmake -Bbuild src
+      # - name: Generate compilation database
+      #   if: steps.cache-build.outputs.cache-hit != 'true'
+      #   run: mkdir build && cmake -Bbuild src
+      
+      # - name: Move database to src folder
+      #   run: mv build/compile_commands.json src/
 
       - name: run linter as action
         uses: cpp-linter/cpp-linter-action@backlogged-updates
@@ -39,7 +42,7 @@ jobs:
           files-changed-only: ${{ matrix.clang-version == '12' }}
           # to ignore all build folder contents
           ignore: build
-          database: build
+          # database: build
           verbosity: 9
           version: ${{ matrix.clang-version }}
           file-annotations: ${{ matrix.clang-version == '12' }}

--- a/.github/workflows/cpp-lint-action.yml
+++ b/.github/workflows/cpp-lint-action.yml
@@ -28,7 +28,7 @@ jobs:
         run: mkdir build && cmake -Bbuild src
 
       - name: run linter as action
-        uses: cpp-linter/cpp-linter-action@latest
+        uses: cpp-linter/cpp-linter-action@backlogged-updates
         id: linter
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cpp-lint-action.yml
+++ b/.github/workflows/cpp-lint-action.yml
@@ -28,12 +28,12 @@ jobs:
       # - name: Generate compilation database
       #   if: steps.cache-build.outputs.cache-hit != 'true'
       #   run: mkdir build && cmake -Bbuild src
-      
+
       # - name: Move database to src folder
       #   run: mv build/compile_commands.json src/
 
       - name: run linter as action
-        uses: cpp-linter/cpp-linter-action@backlogged-updates
+        uses: cpp-linter/cpp-linter-action@latest
         id: linter
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -45,7 +45,7 @@ jobs:
           # database: build
           verbosity: 9
           version: ${{ matrix.clang-version }}
-          file-annotations: ${{ matrix.clang-version == '12' }}
+          thread-comments: ${{ matrix.clang-version == '12' }}
 
       - name: Fail fast?!
         if: steps.linter.outputs.checks-failed > 0

--- a/.github/workflows/cpp-lint-package.yml
+++ b/.github/workflows/cpp-lint-package.yml
@@ -11,12 +11,14 @@ jobs:
       matrix:
         clang-version: ['9','10', '11', '12', '13', '14']
         repo: ['cpp-linter/cpp-linter-action']
-        branch: ['latest']
+        branch: ['backlogged-updates']
       fail-fast: false
 
     steps:
 
       - uses: actions/checkout@v3
+        with:
+          submodules: true
       - uses: actions/setup-python@v3
       - name: Install clang-tools
         uses: KyleMayes/install-llvm-action@v1

--- a/.github/workflows/cpp-lint-package.yml
+++ b/.github/workflows/cpp-lint-package.yml
@@ -28,7 +28,9 @@ jobs:
 
       - name: Install linter package
         run: python3 -m pip install git+https://github.com/${{ matrix.repo }}/@${{ matrix.branch }}
-
+      
+      - uses: seanmiddleditch/gha-setup-vsdevenv@v4
+      
       - name: Cache the build artifacts
         id: cache-build
         uses: actions/cache@v3

--- a/.github/workflows/cpp-lint-package.yml
+++ b/.github/workflows/cpp-lint-package.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Generate  compiler database
         if: steps.cache-build.outputs.cache-hit != 'true'
-        run: mkdir build && cmake -Bbuild src
+        run: mkdir build && cmake -Bbuild src -G "NMake Makefiles"
 
       - name: run linter as package
         id: linter

--- a/.github/workflows/cpp-lint-package.yml
+++ b/.github/workflows/cpp-lint-package.yml
@@ -9,9 +9,9 @@ jobs:
 
     strategy:
       matrix:
-        clang-version: ['9','10', '11', '12', '13', '14']
+        clang-version: ['7', '8', '9','10', '11', '12', '13', '14']
         repo: ['cpp-linter/cpp-linter-action']
-        branch: ['backlogged-updates']
+        branch: ['latest']
       fail-fast: false
 
     steps:
@@ -19,18 +19,18 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: actions/setup-python@v3
-      - name: Install clang-tools
-        uses: KyleMayes/install-llvm-action@v1
-        with:
-          version: ${{ matrix.clang-version }}
-          directory: ${{ runner.temp }}/llvm
 
-      - name: Install linter package
-        run: python3 -m pip install git+https://github.com/${{ matrix.repo }}/@${{ matrix.branch }}
-      
-      - uses: seanmiddleditch/gha-setup-vsdevenv@v4
-      
+      - uses: actions/setup-python@v4
+
+      - name: install workflow deps
+        run: python -m pip install clang-tools git+https://github.com/${{ matrix.repo }}/@${{ matrix.branch }}
+
+      - name: Install clang-tools
+        run: clang-tools -install ${{ matrix.clang-version }} --directory ${{ runner.temp }}/llvm
+
+      - name: Setup VS dev env
+        uses: seanmiddleditch/gha-setup-vsdevenv@v4
+
       - name: Cache the build artifacts
         id: cache-build
         uses: actions/cache@v3

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "cpp-linter-action"]
+	path = cpp-linter-action
+	url = https://github.com/cpp-linter/cpp-linter-action.git

--- a/src/demo.cpp
+++ b/src/demo.cpp
@@ -3,6 +3,7 @@
 #include <cstdio>
 #include <cstddef>
 
+// using size_t from cstddef
 size_t dummyFunc(size_t i) { return i; }
 
 int main()

--- a/src/demo.cpp
+++ b/src/demo.cpp
@@ -7,8 +7,7 @@ size_t dummyFunc(size_t i) { return i; }
 
 int main()
 {
-    for (;;)
-        break;
+    for (;;) break;
 
     printf("Hello world!\n");
 

--- a/src/demo.cpp
+++ b/src/demo.cpp
@@ -8,7 +8,8 @@ size_t dummyFunc(size_t i) { return i; }
 
 int main()
 {
-    for (;;) break;
+    for (;;)
+        break;
 
     printf("Hello world!\n");
 

--- a/src/demo.hpp
+++ b/src/demo.hpp
@@ -9,7 +9,7 @@ class Dummy {
     public:
     void *not_usefull(char *str){
         useless = str;
-        return 0;
+        return nullptr;
     }
 };
 
@@ -37,5 +37,4 @@ class Dummy {
 struct LongDiff
 {
     long diff;
-
 };

--- a/src/demo.hpp
+++ b/src/demo.hpp
@@ -9,7 +9,7 @@ class Dummy {
     public:
     void *not_usefull(char *str){
         useless = str;
-        return nullptr;
+        return 0;
     }
 };
 
@@ -37,4 +37,5 @@ class Dummy {
 struct LongDiff
 {
     long diff;
+
 };


### PR DESCRIPTION
~This PR is just for testing PR events on the `backlogged-updates` branch. It is not meant to actually get merged.~ 

It wouldn't hurt to merge this for the submodule and improvements to generating the compilation database on Windows.

I had to disable the `database` option for the workflow that runs the action with a docker env because it prevents the file annotations from being created.